### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/home-manager/eternal/home.nix
+++ b/home-manager/eternal/home.nix
@@ -84,6 +84,6 @@ in {
   # Nicely reload system units when changing configs
   systemd.user.startServices = "sd-switch";
 
-  # https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
+  # https://wiki.nixos.org/wiki/FAQ/When_do_I_update_stateVersion
   home.stateVersion = "24.05";
 }

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,4 +1,4 @@
-# Add your reusable home-manager modules to this directory, on their own file (https://nixos.wiki/wiki/Module).
+# Add your reusable home-manager modules to this directory, on their own file (https://wiki.nixos.org/wiki/Module).
 # #These should be stuff you would like to share with others, not your personal configurations.
 {
   # List your module files here

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,4 @@
-# Add your reusable NixOS modules to this directory, on their own file (https://nixos.wiki/wiki/Module).
+# Add your reusable NixOS modules to this directory, on their own file (https://wiki.nixos.org/wiki/Module).
 # These should be stuff you would like to share with others, not your personal configurations.
 {
   # List your module files here

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -5,7 +5,7 @@
 
   # This one contains whatever you want to overlay
   # You can change versions, add patches, set compilation flags, anything really.
-  # https://nixos.wiki/wiki/Overlays
+  # https://wiki.nixos.org/wiki/Overlays
   modifications = final: prev: {
     # example = prev.example.overrideAttrs (oldAttrs: rec {
     # ...


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️